### PR TITLE
Update baseline to 2.112

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.111</jenkins.version> <!-- TODO 2.112 once released -->
+        <jenkins.version>2.112</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>JDK Tool Plugin</name>


### PR DESCRIPTION
Prevents users of Jenkins 2.111 from installing the plugin.

@reviewbybees