### PR TITLE
Make the tar extraction of a JDK less verbose

### DIFF
--- a/src/main/java/hudson/tools/JDKInstaller.java
+++ b/src/main/java/hudson/tools/JDKInstaller.java
@@ -203,7 +203,7 @@ public class JDKInstaller extends ToolInstaller {
 
             ProcStarter starter;
             if (header[0]==0x1F && header[1]==(byte)0x8B) {// gzip
-                starter = launcher.launch().cmds("tar", "xvzf", jdkBundle);
+                starter = launcher.launch().cmds("tar", "xzf", jdkBundle);
             } else {
                 fs.chmod(jdkBundle,0755);
                 starter = launcher.launch().cmds(jdkBundle, "-noregister");


### PR DESCRIPTION
Currently we have to scroll through many pages of JDK installation tar output at the beginning on our job's console output.  Specifically, jdk1.8.0_131 includes 1830 files that get traced out.  The easiest solution seems to be to eliminate the verbose "v" option.