### PR TITLE
Added warning about license change for Oracle Java

### DIFF
--- a/src/main/resources/hudson/tools/JDKInstaller/config.jelly
+++ b/src/main/resources/hudson/tools/JDKInstaller/config.jelly
@@ -47,11 +47,11 @@ THE SOFTWARE.
   <f:entry title="" field="acceptLicense">
     <f:checkbox title="${%I agree to the Java SE Development Kit License Agreement}"/>
   </f:entry>
-  <f:entry>
+  <f:block>
     <div class="warning">
       Oracle Java SE 11+ is not available for business, commercial or production use without a commercial license.<br />
       Public updates for Oracle Java SE 8 released after January 2019 will not be available for business, commercial or production use without a commercial license.<br />
       <a href="https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html" target="_blank">Oracle Java SE Licensing FAQ</a><br />
     </div>
-  </f:entry>
+  </f:block>
 </j:jelly>

--- a/src/main/resources/hudson/tools/JDKInstaller/config.jelly
+++ b/src/main/resources/hudson/tools/JDKInstaller/config.jelly
@@ -49,9 +49,9 @@ THE SOFTWARE.
   </f:entry>
   <f:block>
     <div class="warning">
-      Oracle Java SE 11+ is not available for business, commercial or production use without a commercial license.<br />
-      Public updates for Oracle Java SE 8 released after January 2019 will not be available for business, commercial or production use without a commercial license.<br />
-      <a href="https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html" target="_blank">Oracle Java SE Licensing FAQ</a><br />
+      ${%Oracle Java SE 11+ is not available for business, commercial or production use without a commercial license.}<br />
+      ${%Public updates for Oracle Java SE 8 released after January 2019 will not be available for business, commercial or production use without a commercial license.}<br />
+      <a href="https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html" target="_blank">${%Oracle Java SE Licensing FAQ}</a><br />
     </div>
   </f:block>
 </j:jelly>

--- a/src/main/resources/hudson/tools/JDKInstaller/config.jelly
+++ b/src/main/resources/hudson/tools/JDKInstaller/config.jelly
@@ -47,4 +47,11 @@ THE SOFTWARE.
   <f:entry title="" field="acceptLicense">
     <f:checkbox title="${%I agree to the Java SE Development Kit License Agreement}"/>
   </f:entry>
+  <f:entry>
+    <div class="warning">
+      Oracle Java SE 11+ is not available for business, commercial or production use without a commercial license.<br />
+      Public updates for Oracle Java SE 8 released after January 2019 will not be available for business, commercial or production use without a commercial license.<br />
+      <a href="https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html" target="_blank">Oracle Java SE Licensing FAQ</a><br />
+    </div>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Oracle has changed license for their Java SE and this PR add a warning text and a link to their Oracle Java SE Licensing FAQ.

If [Include all Oracle JDKs #82](https://github.com/jenkins-infra/crawler/pull/82) gets merged and we add support for all Oracle Java versions starting from 1.4 it would be best if the user is informed about Oracle Java licensing.