### PR TITLE
Move the plugin documentation from Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Oracle Java SE Development Kit Installer Plugin
 ===============================================
 
 This plugin provides a toool installer for installing [Oracle Java SE Development Kit](https://www.oracle.com/technetwork/java/javase/) in Jenkins. 
-See this [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/JDK+Tool+Plugin).
 
 The installer provided by the plugin used to be a part of the Jenkins core before it was detached to a separate plugin in [Jenkins 2.112](https://jenkins.io/changelog/#v2.112). 
 Before version `1.3` the plugin was named as "JDK Tool Plugin", but it was renamed later to reflect what it actually does.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,19 @@ Oracle Java SE Development Kit Installer Plugin
 
 This plugin provides a toool installer for installing [Oracle Java SE Development Kit](https://www.oracle.com/technetwork/java/javase/) in Jenkins. 
 See this [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/JDK+Tool+Plugin).
-This plugin was formerly known as "JDK Tool Plugin", but it was renamed in order to reflect what it actually does.
+
+The installer provided by the plugin used to be a part of the Jenkins core before it was detached to a separate plugin in [Jenkins 2.112](https://jenkins.io/changelog/#v2.112). 
+Before version `1.3` the plugin was named as "JDK Tool Plugin", but it was renamed later to reflect what it actually does.
+
+## Usage recommendations
+
+We want to warn that this plugin is **NOT** a good practice for production environments. 
+As it relies on the Oracle's website to do the job, it's highly likely to stop working. 
+It could happen because Oracle's website change or even if Oracle bans our downloads due to excessive bandwidth or whatever other reason). 
+
+The recommended approach is to download the JDK distribution using other installers, for example downloading it from a well known URL (preferably hosted on your own network) with _ZIP Tool Installer_, having it pre-installed in agent docker images, or executing a script to do the job.
+If an external download is needed due to any reason, 
+[AdoptOpenJDK Plugin](https://plugins.jenkins.io/adoptopenjdk) might be used instead of this plugin.
 
 ## License constraints
 
@@ -14,11 +26,3 @@ There are some license constraints which should be taken into account while usin
 
 See [Oracle Java SE License FAQ](https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html) for more information.
 If you use this plugin on your instance, make sure to be compliant with license terms.
-
-## Alternative solutions
-
-As a general recommendation, it is advised not to rely on external downloads in your CI systems.
-For example, JDK can be preinstalled in Docker images.
-ZIP Tool Installer can be also used to download the JDK tool from a local infrastructure.
-If an external download is needed due to any reason, 
-[AdoptOpenJDK Plugin](https://plugins.jenkins.io/adoptopenjdk) might be used instead of this plugin.


### PR DESCRIPTION
Apparently Wiki already had some text for usage constraints, created by @dwnusbaum during the plugin split. I went ahead and integrated original text from https://wiki.jenkins.io/display/JENKINS/JDK+Tool+Plugin 

Once the change is integrated, we can replace Wiki by the reference docs

CC @jenkinsci/java11-support 
