### PR TITLE
[JENKINS-69860] - onclick usage un-inlined for CSP compliance.

### DIFF
--- a/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/credentialOK.jelly
+++ b/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/credentialOK.jelly
@@ -23,12 +23,15 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+
+  <st:adjunct includes="hudson.tools.JDKInstaller.DescriptorImpl.credentialOk" />
+
   <l:layout title="${%title}">
     <l:main-panel>
       <p>
         ${%saved}
       </p>
-      <input type="button" value="${%Close}" class="yui-button" onclick="window.close()" />
+      <input id="credentialOkInput" type="button" value="${%Close}" class="yui-button"/>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/credentialOK.js
+++ b/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/credentialOK.js
@@ -1,0 +1,8 @@
+
+document.addEventListener('DOMContentLoaded', (event) => {
+
+    const credentialOkInput = document.getElementById("credentialOkInput");
+
+    credentialOkInput.onclick = (_) => window.close();
+
+});


### PR DESCRIPTION
**The issue**
You can find all the issue details [here](https://issues.jenkins.io/browse/JENKINS-69860).

**My updates:**
I've created a *credentialOK.js* file to externalized the javascript and I've updated the *credentialOK.jelly* file.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
